### PR TITLE
Fix I/O hang after received a large deflate frame

### DIFF
--- a/lib/plat/windows/windows-service.c
+++ b/lib/plat/windows/windows-service.c
@@ -166,8 +166,10 @@ _lws_plat_service_tsi(struct lws_context *context, int timeout_ms, int tsi)
 			if (pfd->revents & LWS_POLLHUP)
 				--eIdx;
 
-			if (pfd->revents)
+			if (pfd->revents) {
+				recv(pfd->fd, NULL, 0, 0);
 				lws_service_fd_tsi(context, pfd, tsi);
+			}
 		}
 	}
 


### PR DESCRIPTION
When a large deflate frame been received, WSAEnumNetworkEvents will indicate the socket is ready to read. And because the frame is compressed, it may not be consumed entirely(not all bytes ready to receive have been received), since WSAEnumNetworkEvents is edge triggered, and the socket read buffer never been drained, WSAEnumNetworkEvents will never indicate the socket is ready to read again. What here need is level trigger behavior, thus add additional recv with empty buffer to reset edge status.